### PR TITLE
Support large secrets (> 128 chars)

### DIFF
--- a/src/handler_functions.rs
+++ b/src/handler_functions.rs
@@ -35,9 +35,9 @@ type UserDataImpl = GetUserDataLdapBackend;
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b'/').add(b'=');
 /// max length of form data
-const MAX_FORM_BYTES_LEN: usize = 1024;
+const MAX_FORM_BYTES_LEN: usize = 10100 * 10;
 /// max length of form fields
-const MAX_FORM_INPUT_LEN: usize = 128;
+const MAX_FORM_INPUT_LEN: usize = 10100;
 
 /// Redirect browser to our index page.
 pub async fn redirect_to_index(

--- a/src/rsa_functions.rs
+++ b/src/rsa_functions.rs
@@ -2,6 +2,8 @@ use crate::base64_trait::{Base64StringConversions, Base64VecU8Conversions};
 use crate::unsecure_string::SecureStringToUnsecureString;
 use log::{debug, warn , info};
 use openssl::rsa::{Padding, Rsa};
+use openssl::rand::rand_bytes;
+use openssl::symm::{decrypt, encrypt, Cipher};
 use secstr::SecStr;
 use serde::Deserialize;
 use std::error::Error;
@@ -113,6 +115,99 @@ impl RsaKeys {
                 Ok(base64_encrypted)
             }
         }
+    }
+
+    /// Encrypt a String slice with stored RSA public key. The encryption is
+    /// done in a hybrid mode, meaning, that the payload itself is encrypted
+    /// using AES256 with a generated key, which is in turn encrypted using the
+    /// RSA key.
+    ///
+    /// # Arguments
+    ///
+    /// - `plaintext_data`: a String slice with data to encrypt
+    pub fn hybrid_encrypt_str(&self, plaintext_data: &str) -> Result<String, Box<dyn Error>> {
+        if self.rsa_public_key.is_none() {
+            let box_err: Box<dyn Error> = "RSA public key is not set!".to_string().into();
+            return Err(box_err);
+        }
+
+        // AES Keys to encrypt the payload - the keysize of 256bit can be
+        // encrypted using a 2048 RSA key. A smaller key size makes no sense and
+        // this will result in a panic
+        let mut aes_key = [0; 32];
+        let mut aes_iv = [0; 16];
+        let mut aes_key_iv = Vec::new();
+        rand_bytes(&mut aes_key).unwrap();
+        rand_bytes(&mut aes_iv).unwrap();
+
+        let public_key = self.rsa_public_key.as_ref().unwrap();
+        let mut buf: Vec<u8> = vec![0; public_key.size() as usize];
+
+        aes_key_iv.extend_from_slice(&aes_key);
+        aes_key_iv.extend_from_slice(&aes_iv);
+
+        public_key.public_encrypt(&aes_key_iv, &mut buf, Padding::PKCS1).unwrap();
+
+        let base64_encrypted_key_iv = buf.to_base64_encoded();
+
+        let cipher = Cipher::aes_256_cbc();
+
+        let ciphertext = encrypt(
+            cipher,
+            &aes_key,
+            Some(&aes_iv),
+            plaintext_data.as_bytes()).unwrap();
+
+        let payload = ciphertext.to_base64_encoded();
+
+        return Ok(format_args!("v1.{base64_encrypted_key_iv}.{payload}").to_string());
+    }
+
+    /// Decrypt a string encrypted using the RSA keypair with the
+    /// hybrid_encrypt_str function.
+    ///
+    /// # Arguments
+    ///
+    /// - `encrypted_data`: a String slice with data to decrypt
+    pub fn hybrid_decrypt_str(&self, encrypted_data: &str) -> Result<String, Box<dyn Error>> {
+        if self.rsa_private_key.is_none() {
+            let box_err: Box<dyn Error> = "RSA private key is not set!".to_string().into();
+            return Err(box_err);
+        }
+
+        let elements: Vec<&str> = encrypted_data.split('.').collect();
+
+        let encryption_scheme = elements.get(0).unwrap();
+
+        if "v1" != *encryption_scheme {
+            let box_err: Box<dyn Error> = format_args!("Unsupported encryption scheme: {}", encryption_scheme).to_string().into();
+            return Err(box_err);
+        }
+
+        if elements.len() != 3 {
+            let box_err: Box<dyn Error> = format_args!("Expected {} parts, but found  {}", 3, elements.len()).to_string().into();
+            return Err(box_err);
+        }
+
+        let encrypted_key_iv = Vec::from_base64_encoded(elements.get(1).unwrap())?;
+        let encrypted_payload = Vec::from_base64_encoded(elements.get(2).unwrap())?;
+
+        let public_key = self.rsa_public_key.as_ref().unwrap();
+
+        let private_key = self.rsa_private_key.as_ref().unwrap();
+        let mut aes_key_iv: Vec<u8> = vec![0; public_key.size() as usize];
+        private_key.private_decrypt(&encrypted_key_iv, &mut aes_key_iv, Padding::PKCS1)?;
+
+        let cipher = Cipher::aes_256_cbc();
+
+        let payload = decrypt(
+            cipher,
+            &aes_key_iv.as_slice()[0..32],
+            Some(&aes_key_iv.as_slice()[32..48]),
+            &encrypted_payload
+        ).unwrap();
+
+        return Ok(String::from_utf8(payload)?.trim_matches(char::from(0)).to_string());
     }
 
     /// Decrypt a base64 encoded String slice with stored RSA private key

--- a/src/secret_functions.rs
+++ b/src/secret_functions.rs
@@ -105,12 +105,12 @@ impl Secret {
     /// Creates a new instance of `Secret` with
     /// encrypted data.
     pub fn to_encrypted(&self, rsa_keys: &RsaKeys) -> Result<Secret, Box<dyn Error>> {
-        let encrypted_from_email = rsa_keys.encrypt_str(&self.from_email)?;
-        let encrypted_from_display_name = rsa_keys.encrypt_str(&self.from_display_name)?;
-        let encrypted_to_email = rsa_keys.encrypt_str(&self.to_email)?;
-        let encrypted_to_display_name = rsa_keys.encrypt_str(&self.to_display_name)?;
-        let encrypted_context = rsa_keys.encrypt_str(&self.context)?;
-        let encrypted_secret = rsa_keys.encrypt_str(&self.secret)?;
+        let encrypted_from_email = rsa_keys.hybrid_encrypt_str(&self.from_email)?;
+        let encrypted_from_display_name = rsa_keys.hybrid_encrypt_str(&self.from_display_name)?;
+        let encrypted_to_email = rsa_keys.hybrid_encrypt_str(&self.to_email)?;
+        let encrypted_to_display_name = rsa_keys.hybrid_encrypt_str(&self.to_display_name)?;
+        let encrypted_context = rsa_keys.hybrid_encrypt_str(&self.context)?;
+        let encrypted_secret = rsa_keys.hybrid_encrypt_str(&self.secret)?;
         let secret = Secret {
             from_email: encrypted_from_email,
             from_display_name: encrypted_from_display_name,
@@ -125,12 +125,24 @@ impl Secret {
     /// Creates a new instance of `Secret` with
     /// decrypted data.
     pub fn to_decrypted(&self, rsa_keys: &RsaKeys) -> Result<Secret, Box<dyn Error>> {
-        let decrypted_from_email = rsa_keys.decrypt_str(&self.from_email)?;
-        let decrypted_from_display_name = rsa_keys.decrypt_str(&self.from_display_name)?;
-        let decrypted_to_email = rsa_keys.decrypt_str(&self.to_email)?;
-        let decrypted_to_display_name = rsa_keys.decrypt_str(&self.to_display_name)?;
-        let decrypted_context = rsa_keys.decrypt_str(&self.context)?;
-        let decrypted_secret = rsa_keys.decrypt_str(&self.secret)?;
+        let decrypted_from_email = if *(&self.from_email.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.from_email)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.from_email)?};
+        let decrypted_from_display_name = if *(&self.from_display_name.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.from_display_name)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.from_display_name)?};
+        let decrypted_to_email = if *(&self.to_email.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.to_email)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.to_email)?};
+        let decrypted_to_display_name = if *(&self.to_display_name.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.to_display_name)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.to_display_name)?};
+        let decrypted_context = if *(&self.context.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.context)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.context)?};
+        let decrypted_secret = if *(&self.secret.find('.').is_none())
+            { rsa_keys.decrypt_str(&self.secret)? }
+            else { rsa_keys.hybrid_decrypt_str(&self.secret)?};
         let secret = Secret {
             from_email: decrypted_from_email,
             from_display_name: decrypted_from_display_name,

--- a/tests/rsa_functions.rs
+++ b/tests/rsa_functions.rs
@@ -54,3 +54,60 @@ fn rsa_functions() {
         "rsa encrypted data should not be equal after 2 calls!"
     );
 }
+
+
+#[test]
+fn rsa_functions_hybrid() {
+    const RSA_PASSPHRASE: &str = "12345678901234";
+    // see https://www.rfc-editor.org/rfc/rfc3548#section-3
+    const BASE64_REGEX: &str = r"^[A-Za-z0-9\+/=.]+$";
+    let base64_regex = Regex::new(BASE64_REGEX).unwrap();
+    const PLAINTEXT: &str = "plaintext";
+
+    let secure_rsa_passphrase = SecStr::from(RSA_PASSPHRASE);
+    let mut rsa_keys = RsaKeys::new();
+    if let Err(e) = rsa_keys.read_from_files(
+        Path::new(WORKSPACE_DIR).join("ignore/lmtyas_rsa_private.key"),
+        Path::new(WORKSPACE_DIR).join("ignore/lmtyas_rsa_public.key"),
+        &secure_rsa_passphrase,
+    ) {
+        panic!("cannot load rsa keys! {}", &e);
+    };
+
+    let rsa_encrytpted = rsa_keys.hybrid_encrypt_str(PLAINTEXT);
+    let rsa_encrytpted2 = rsa_keys.hybrid_encrypt_str(PLAINTEXT);
+    let rsa_encrypted_unwrapped = match rsa_encrytpted {
+        Ok(r) => r,
+        Err(e) => {
+            panic!("cannot unwrap rsa hybrid encrypted result! {}", &e);
+        }
+    };
+    let rsa_encrypted_unwrapped2 = match rsa_encrytpted2 {
+        Ok(r) => r,
+        Err(e) => {
+            panic!("cannot unwrap rsa hybrid encrypted result2! {}", &e);
+        }
+    };
+
+    assert!(
+        base64_regex.is_match(&rsa_encrypted_unwrapped),
+        "rsa hybrid encrypted data is not converted correctly to base64: {}",
+        &rsa_encrypted_unwrapped
+    );
+    let decrypted = rsa_keys.hybrid_decrypt_str(&rsa_encrypted_unwrapped);
+    assert_eq!(
+        PLAINTEXT,
+        decrypted.unwrap(),
+        "rsa hybrid decrypted message does not match plaintext!"
+    );
+    assert_ne!(
+        rsa_encrypted_unwrapped, rsa_encrypted_unwrapped2,
+        "rsa hybrid encrypted data should not be equal after 2 calls!"
+    );
+
+    assert!(
+        rsa_keys.hybrid_decrypt_str("RHVtbXk=").is_err(),
+        "inputting invalid data into hybrid_decrypt_str should yield error"
+    );
+
+}

--- a/web-content/admin-html/sysop.html
+++ b/web-content/admin-html/sysop.html
@@ -79,13 +79,12 @@
                 </form>
             </div>
         </div>
-        </div>
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/admin-html/sysop.html
+++ b/web-content/admin-html/sysop.html
@@ -37,11 +37,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
@@ -53,7 +53,7 @@
         </p>
     </noscript>
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div>
             <br />
             <br />
@@ -80,7 +80,7 @@
             </div>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/authenticated/reveal.html
+++ b/web-content/authenticated/reveal.html
@@ -70,16 +70,17 @@
                     <p>
                         <label for="FromDisplayName">Display name of sender</label>
                         <input id="FromDisplayName" name="FromDisplayName" maxlength="128"
-                            placeholder="Givenname LastName" value="" disabled>
+                            placeholder="Givenname LastName" value="" readonly>
                         <label for="FromEmail">EMail address of sender</label>
                         <input id="FromEmail" name="FromEmail" maxlength="128"
-                            placeholder="firstname.lastname@acme.local" value="" disabled>
+                            placeholder="firstname.lastname@acme.local" value="" readonly>
                     </p>
                     <h2>Secret</h2>
                     <label for="Context">Context</label>
-                    <input id="Context" name="Context" maxlength="256" placeholder="secret for..." value="" disabled>
+                    <input id="Context" name="Context" maxlength="256" placeholder="secret for..." value="" readonly>
                     <label for="Secret">Secret</label>
-                    <input id="Secret" name="Secret" maxlength="128" placeholder="secret information" value="">
+                    <textarea id="Secret" name="Secret" readonly
+                              placeholder="secret information"></textarea>
                     <p>
                     </p>
                     <p>

--- a/web-content/authenticated/reveal.html
+++ b/web-content/authenticated/reveal.html
@@ -37,11 +37,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
@@ -57,7 +57,7 @@
         Service is not ready for operation, please inform system administrator!
     </div>
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div id="ServiceIsReady" class="lmtyas-none">
             <br />
             <br />
@@ -91,7 +91,7 @@
             </div>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/authenticated/reveal.html
+++ b/web-content/authenticated/reveal.html
@@ -93,9 +93,9 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/authenticated/tell.html
+++ b/web-content/authenticated/tell.html
@@ -69,28 +69,29 @@
                     <p>
                         <label for="FromDisplayName">Display name of sender</label>
                         <input id="FromDisplayName" name="FromDisplayName" maxlength="128"
-                            placeholder="Givenname LastName" value="" disabled>
+                            placeholder="Givenname LastName" value="" readonly>
                         <label for="FromEmail">EMail address of sender</label>
                         <input id="FromEmail" name="FromEmail" maxlength="128"
-                            placeholder="firstname.lastname@acme.local" value="" disabled>
+                            placeholder="firstname.lastname@acme.local" value="" readonly>
                     </p>
                     <h2>Receiver of secret</h2>
-                    <p>
-                        <!-- <label for="ToDisplayName">Display name of receiver</label> -->
-                        <input id="ToDisplayName" name="ToDisplayName" type="hidden" maxlength="128"
-                            placeholder="Givenname LastName" value="" disabled>
-                        <label for="ToEmail">Email address of receiver</label>
-                        <input id="ToEmail" name="ToEmail" type="email" maxlength="128"
-                            placeholder="firstname.lastname@acme.local" value="" required
-                            pattern="^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,5}|[0-9]{1,3})(\]?)$">
-                    </p>
+                    <!-- <label for="ToDisplayName">Display name of receiver</label> -->
+                    <input id="ToDisplayName" name="ToDisplayName" type="hidden" maxlength="128"
+                        placeholder="Givenname LastName" value="" readonly>
+                    <label for="ToEmail">Email address of receiver</label>
+                    <input id="ToEmail" name="ToEmail" type="email" maxlength="128"
+                        placeholder="firstname.lastname@acme.local" value="" required
+                        pattern="^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,5}|[0-9]{1,3})(\]?)$">
+                    <div class="lmtyas-input-hint" data-for="ToEmail"></div>
                     <h2>Secret</h2>
                     <label for="Context">Context</label>
                     <input id="Context" name="Context" minlength="2" maxlength="128" placeholder="secret for..."
                         value="" required>
+                    <div class="lmtyas-input-hint" data-for="Context"></div>
                     <label for="Secret">Secret</label>
-                    <input id="Secret" name="Secret" minlength="3" maxlength="96"
-                        placeholder="secret information like a password" value="" required>
+                    <textarea id="Secret" name="Secret" data-maxlength="8000"
+                        placeholder="secret information like a password" required></textarea>
+                    <div class="lmtyas-input-hint" data-for="Secret"></div>
                     <p>
                     </p>
                     <p>

--- a/web-content/authenticated/tell.html
+++ b/web-content/authenticated/tell.html
@@ -37,11 +37,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
@@ -57,7 +57,7 @@
         Service is not ready for operation, please inform system administrator!
     </div>
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div id="ServiceIsReady" class="lmtyas-none">
             <br />
             <br />
@@ -102,7 +102,7 @@
             </div>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/authenticated/tell.html
+++ b/web-content/authenticated/tell.html
@@ -104,9 +104,9 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/authentication-ldap/ldap.html
+++ b/web-content/authentication-ldap/ldap.html
@@ -89,9 +89,9 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/authentication-ldap/ldap.html
+++ b/web-content/authentication-ldap/ldap.html
@@ -36,11 +36,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
             alt="let-me-tell-you-a-secret service logo">
         <h2>Let me tell you a secret</h1>
@@ -54,7 +54,7 @@
 
 
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div>
             <br />
             <br />
@@ -87,7 +87,7 @@
         </div>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/authentication-ldap/nothing-here.html
+++ b/web-content/authentication-ldap/nothing-here.html
@@ -54,8 +54,8 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="Home" href="/index.html">Home</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
 </body>

--- a/web-content/authentication-ldap/nothing-here.html
+++ b/web-content/authentication-ldap/nothing-here.html
@@ -37,22 +37,22 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
     </nav>
 
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <h1>Nothing here!</h1>
         <a href="/" target="_self">&gt;&gt;&gt;back to start&lt;&lt;&lt;</a>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="About" href="/about.html">About</a>

--- a/web-content/authentication-oidc/login-fail.html
+++ b/web-content/authentication-oidc/login-fail.html
@@ -64,8 +64,8 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="Home" href="/index.html">Home</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
 </body>

--- a/web-content/authentication-oidc/login-fail.html
+++ b/web-content/authentication-oidc/login-fail.html
@@ -37,18 +37,18 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
     </nav>
 
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <br />
         <br />
         <div class="lmtyas-error-bg">
@@ -62,7 +62,7 @@
             <center><a href="/" target="_self">&gt;&gt;&gt;&nbsp;back to start&nbsp;&lt;&lt;&lt;</a></center>
         </p>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="About" href="/about.html">About</a>

--- a/web-content/authentication-oidc/nothing-here.html
+++ b/web-content/authentication-oidc/nothing-here.html
@@ -54,8 +54,8 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="Home" href="/index.html">Home</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
 </body>

--- a/web-content/authentication-oidc/nothing-here.html
+++ b/web-content/authentication-oidc/nothing-here.html
@@ -37,22 +37,22 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
     </nav>
 
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <h1>Nothing here!</h1>
         <a href="/" target="_self">&gt;&gt;&gt;back to start&lt;&lt;&lt;</a>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="About" href="/about.html">About</a>

--- a/web-content/static/404.html
+++ b/web-content/static/404.html
@@ -37,21 +37,21 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
     </nav>
 
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <h1>404 - not found!</h1>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="About" href="/about.html">About</a>

--- a/web-content/static/404.html
+++ b/web-content/static/404.html
@@ -53,8 +53,8 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="Home" href="/index.html">Home</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
 </body>

--- a/web-content/static/about.html
+++ b/web-content/static/about.html
@@ -145,9 +145,9 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/static/about.html
+++ b/web-content/static/about.html
@@ -37,11 +37,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
@@ -57,7 +57,7 @@
         Service is not ready for operation, please inform system administrator!
     </div>
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div>
             <h1 id="let-me-tell-you-a-secret">Let me tell you a secret</h1>
             <p>A web service written in Rust that allows an authenticated user to send secrets like passwords to other
@@ -143,7 +143,7 @@
                 encrypted by a randomly chosen key/iv.</p>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/static/css/colors.css
+++ b/web-content/static/css/colors.css
@@ -4,6 +4,7 @@
     --input-ok-border: #49b35b;
     --error-bg: #9D132A;
     --error-font: #FFFFFF;
+    --error-border: red;
     --ok-bg: #49b35b;
     --ok-font: #FFFFFF;
     --form-bg:  #EEEEEE;

--- a/web-content/static/css/lmtyas.css
+++ b/web-content/static/css/lmtyas.css
@@ -25,7 +25,7 @@ body{
 
 .lmtyas-nav-links{
     background-color: var(--header-links-bg);
-    color: --var(--header-links-font);
+    color: var(--header-links-font);
     padding-top: 10px;
     padding-bottom: 10px;
     font-weight: bold;
@@ -34,7 +34,7 @@ body{
 }
 
 .lmtyas-nav-links a:hover{
-    background-color: --var(--header-links-hover-bg);
+    background-color: var(--header-links-hover-bg);
     color: var(--header-links-hover-font);
     padding-left: 20px;
     padding-right: 20px;
@@ -77,9 +77,9 @@ ul {
 ul li::before {
     content: "\25A0";
     color: var(--ul-link-before);
-    display: inline-block; 
+    display: inline-block;
     width: 0.5em;
-    margin-left: -1.0 em;
+    margin-left: -1.0em;
 }
 
 .mid {
@@ -244,13 +244,13 @@ input:valid {
 .lmtyas-none{
     display: none;
 }
-  
+
   /* Safari */
 @-webkit-keyframes spin {
     0% { -webkit-transform: rotate(0deg); }
     100% { -webkit-transform: rotate(360deg); }
 }
-  
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/web-content/static/css/lmtyas.css
+++ b/web-content/static/css/lmtyas.css
@@ -89,7 +89,7 @@ ul li::before {
     padding-top:1em;
 }
 
-input {
+input, textarea {
     width: 100%;
     padding: 12px 20px;
     margin: 8px 0;
@@ -97,6 +97,17 @@ input {
     border: 1px solid var(--input-border);
     border-radius: 4px;
     box-sizing: border-box;
+}
+
+textarea {
+    min-height: 10em;
+    resize: vertical;
+}
+
+.lmtyas-input-hint {
+    font-size: 70%;
+    margin-top: -8px;
+    margin-bottom: 8px;
 }
 
 .lmtyas-image{
@@ -128,7 +139,10 @@ textarea:-moz-read-only { /* For Firefox */
     background-color: var(--input-ro-bg);
 }
 
-input:invalid {
+input:invalid,
+textarea:invalid,
+input.invalid,
+textarea.invalid {
     border: 2px dashed var(--error-border);
 }
 

--- a/web-content/static/index.html
+++ b/web-content/static/index.html
@@ -87,9 +87,9 @@
     </main>
     <footer role="contentinfo" class="lmtyas-footer">
         <div align="center">
-            <a id="Home" href="/index.html" target="" _self">Home</a>
+            <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>
-            <a id="About" href="/about.html" target="" _self">About</a>
+            <a id="About" href="/about.html">About</a>
         </div>
     </footer>
     <script src="/js/lmtyas.js"></script>

--- a/web-content/static/index.html
+++ b/web-content/static/index.html
@@ -37,11 +37,11 @@
 </head>
 
 <body>
-    <header role="banner" class="lmtyas-header">
+    <header class="lmtyas-header">
         <img class="lmtyas-company-image" src="/gfx/company-logo.png" alt="Let me tell you a secret company logo"><br />
     </header>
 
-    <nav role="navigation" class="lmtyas-nav">
+    <nav class="lmtyas-nav">
         <a href="/index.html"><img class="lmtyas-favicon" src="/gfx/favicon.png" width="128" height="128"
                 alt="let-me-tell-you-a-secret service logo"></a>
         <h2>Let me tell you a secret</h1>
@@ -57,7 +57,7 @@
         Service is not ready for operation, please inform system administrator!
     </div>
 
-    <main role="main" class="lmtyas-main center">
+    <main class="lmtyas-main center">
         <div>
             <br />
             <br />
@@ -85,7 +85,7 @@
                         secret</a></center>
         </div>
     </main>
-    <footer role="contentinfo" class="lmtyas-footer">
+    <footer class="lmtyas-footer">
         <div align="center">
             <a id="Home" href="/index.html">Home</a>
             <a id="Imprint" href="" target="_blank">Imprint</a>

--- a/web-content/static/js/tell.js
+++ b/web-content/static/js/tell.js
@@ -71,3 +71,30 @@ function errorOnSubmission() {
     console.log("errorOnSubmission()");
     stopForm(secretForm, 6);
 }
+
+if(document.readyState !== "interactive" && document.readyState !== "complete") {
+    function initializer() {
+        document.querySelectorAll(".lmtyas-input-hint").forEach((hintNode) => {
+            const targetId = hintNode.dataset.for;
+            const target = document.getElementById(targetId);
+            let maxLength = null;
+            if("maxlength" in target.dataset) {
+                maxLength = parseInt(target.dataset.maxlength);
+            } else {
+                maxLength = parseInt(target.getAttribute("maxlength"));
+            }
+            function updater() {
+                hintNode.innerText = `${target.value.length} chars (max. ${maxLength})`;
+                if(target.value.length > maxLength) {
+                    target.classList.add("invalid");
+                } else {
+                    target.classList.remove("invalid");
+                }
+            };
+            target.addEventListener("input", updater);
+            target.addEventListener("keyup", updater);
+            updater();
+        });
+    };
+    document.addEventListener("readystatechange", initializer);
+}


### PR DESCRIPTION
While testing lmtyas together with a colleague we faced a problem, that the secret we needed to share was bigger than the supported value and we did not notice that. In this case the secret was a signed JWT, which in turn is used to exchange for an access token at runtime.

The basic problem is, that the RSA function can't be used to directly encrypt values larger than the key length. So instead this PR switches to a hybrid encryption scheme:

- the value itself is encrypted with a generated AES key and IV using AES in CBC mode
- the AES key and IV are then encrypted using the RSA keypair
- the result is encoded as `<VERSION-ID>.<BASE64ENCODED_KEY_IV>.<BASE64ENCODED_PAYLOAD>`

The encoding scheme is basicly a concatenation of BASE64 compatible data. The `VERSION-ID` of course has the be choosen in a compatible manor, but the idea is, that you can split the value at the `.` characters, examine the first component and then do the right post processing. It can also work together with legacy data as `.` are not valid in base64 and thus can't be used to detect new style encoding.

The core change and most important part is in 68b7a1dcf529df4a9fc8d62ebeb2ec3ba7e98140.
While making the adjustments, I noticed some problems in the HTML structure and CSS style sheets (41cf042c02eee6d32806df4b8a035c5aad9fb05b and e0951393162ca4340d792bb10dd552f988d4c52e) and added a few optimizations (e0951393162ca4340d792bb10dd552f988d4c52e).

I can split this PR apart, but I'd like feedback first, whether or not this even the right direction and if there is interest.


The interface now looks like this:

Tell a secret:

![image](https://github.com/hardcodes/lmtyas/assets/2179736/4cf54ac8-a51e-4175-9678-3e8b7c765c0d)

Reveal a secret:

![image](https://github.com/hardcodes/lmtyas/assets/2179736/8a9cb311-c6a8-47d3-b145-ac4cd89b9b0c)
